### PR TITLE
Fix main codebase being skipped by codestyle checking

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -22,7 +22,7 @@ commands =
            --cov={toxinidir}/triscord --cov={toxinidir}/tests --cov-report='' \
            --pylint \
            --pep8 \
-           {toxinidir}/tests
+           {toxinidir}/triscord {toxinidir}/tests
 
 [testenv:coverage]
 basepython = python3

--- a/triscord/persistence.py
+++ b/triscord/persistence.py
@@ -15,7 +15,9 @@ def persistent_storage(file_path, *args, **kwargs):
     if os.path.isfile(file_path):
         file_mode = os.stat(file_path).st_mode
         if bool(stat.S_IWOTH & file_mode):
-            raise RuntimeError('Persistence file %s has insecure permissions', file_path)
+            raise RuntimeError('Persistence file {file_path} has insecure permissions'.format(
+                file_path=file_path,
+            ))
     with shelve.open(file_path, *args, **kwargs) as storage:
         yield storage
 

--- a/triscord/settings.py
+++ b/triscord/settings.py
@@ -10,12 +10,12 @@ class TriscordConfigParser(configparser.ConfigParser):  # pylint: disable=R0901
 
     _loaded = False
 
-    def get(self, *args, **kwargs):
+    def get(self, *args, **kwargs):  # pylint: disable=arguments-differ
         if not self._loaded:
             raise RuntimeError('Settings requested before configuration load.')
         return super().get(*args, **kwargs)
 
-    def _read(self, *args, **kwargs):
+    def _read(self, *args, **kwargs):  # pylint: disable=arguments-differ
         self._loaded = True
         return super()._read(*args, **kwargs)
 

--- a/triscord/trello.py
+++ b/triscord/trello.py
@@ -114,7 +114,7 @@ class TrelloActivityFeed(object):
                 for field_name in self.muted_update_fields:
                     action['data']['old'].pop(field_name, None)
                 if 'listAfter' in action['data'] \
-                    and action['data']['listAfter']['name'] in self.muted_update_lists:
+                        and action['data']['listAfter']['name'] in self.muted_update_lists:
                     continue
                 if not any(action['data']['old'].keys()):
                     continue


### PR DESCRIPTION
Turns out I completely missed adding the main codebase's path to pytest, even before we started using tox.

This had the consequence of only having the test code being checked for code styling issues (by pep8 and pylint).

This PR fixes that issue.